### PR TITLE
Added support for Calc variables

### DIFF
--- a/casual.el
+++ b/casual.el
@@ -205,7 +205,21 @@ V is either nil or non-nil."
      :transient nil)
     ("P" "Pack" calc-pack :transient nil)
     ("U" "Unpack" calc-unpack :transient nil)
-    ("y" "Copy to Buffer" calc-copy-to-buffer :transient nil)]]
+    ("y" "Copy to Buffer" calc-copy-to-buffer :transient nil)
+    ("z" "Variables›" casual-variable-crud-menu :transient nil)]]
+  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+
+(transient-define-prefix casual-variable-crud-menu ()
+  "Casual variable CRUD menu."
+  ["Variable Operations"
+   ("s" "Store (𝟣:)…" calc-store :transient t)
+   ("r" "Recall…" calc-recall :transient t)
+   ("c" "Clear…" calc-unstore :transient t)
+   ("e" "Edit…" calc-edit-variable :transient t)
+   ("o" "Copy to other variable…" calc-copy-variable :transient t)
+   ("x" "Exchange (𝟣:) to variable…" calc-store-exchange :transient t)
+   ("p" "Persist…" calc-permanent-variable :transient t)
+   ("i" "Insert variables into buffer…" calc-insert-variables :transient t)]
   [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-rounding-menu ()
@@ -462,7 +476,7 @@ V is either nil or non-nil."
                     (format "Complex Number Format (now %s)›"
                             (casual-complex-format-label)))
      :transient t)
-    ("M-p" calc-precision
+    ("P" calc-precision
      :description (lambda ()
                     (format "Precision (now %d)" calc-internal-prec))
      :transient t)
@@ -491,7 +505,7 @@ V is either nil or non-nil."
      :transient t)
     ;; TODO show current value thousands separators
     ("," "Set Thousands Separator" calc-group-char :transient t)
-    ("P" "Decimal Separator" calc-point-char :transient t)
+    ("." "Decimal Separator" calc-point-char :transient t)
     ("H" "ℎ𝑚𝑠 Format" calc-hms-notation
      :description (lambda ()
                     (format

--- a/tests/test-casual.el
+++ b/tests/test-casual.el
@@ -218,6 +218,37 @@ A testcase is used as input to `casualt-menu-assert-testcase'."
         (should (math-floatp (calc-top)))))))
   (casualt-breakdown t))
 
+(ert-deftest test-casual-variable-crud-menu ()
+  (casualt-setup)
+
+  (calc-push-list '(25))
+  (funcall 'casual-variable-crud-menu)
+  ;; test (s) calc-store
+  (execute-kbd-macro "sfoo")
+  (should (= (calc-var-value 'var-foo) 25))
+  (calc-pop-stack (calc-stack-size))
+
+  ;; test (r) calc-recall
+  (execute-kbd-macro "rfoo")
+  (should (= (calc-top) 25))
+
+  ;; test (o) calc-copy-variable
+  (execute-kbd-macro "ofoojane")
+  (should (= (calc-var-value 'var-jane) 25))
+
+  ;; test (c) calc-unstore
+  (execute-kbd-macro "cfoo")
+  (should (not (calc-var-value 'var-foo)))
+
+  ;; test (x) calc-store-exchange
+  (calc-push-list '(32))
+  (execute-kbd-macro "xjane")
+  (should (= (calc-var-value 'var-jane) 32))
+
+  ;; TODO: punting on calc-edit-variable
+  ;; TODO: punting on calc-permanent-variable
+  ;; TODO: punting on calc-insert-variables
+  (casualt-breakdown t))
 
 
 (ert-deftest test-casual-binary-menu ()


### PR DESCRIPTION
- New Transient casual-variable-crud-menu includes commands to CRUD variables
  - includes unit test of casual-variable-crud-menu
- Change calc-point-char key to '.'
- Change calc-precision key to 'P'

closes #10 