### PR TITLE
Support enhanced navigation

### DIFF
--- a/casual.el
+++ b/casual.el
@@ -207,7 +207,9 @@ V is either nil or non-nil."
     ("U" "Unpack" calc-unpack :transient nil)
     ("y" "Copy to Buffer" calc-copy-to-buffer :transient nil)
     ("z" "Variables›" casual-variable-crud-menu :transient nil)]]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ;; Note: no need to C-g for main menu
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-variable-crud-menu ()
   "Casual variable CRUD menu."
@@ -220,7 +222,9 @@ V is either nil or non-nil."
    ("x" "Exchange (𝟣:) to variable…" calc-store-exchange :transient t)
    ("p" "Persist…" calc-permanent-variable :transient t)
    ("i" "Insert variables into buffer…" calc-insert-variables :transient t)]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-rounding-menu ()
   "Casual rounding functions menu."
@@ -229,7 +233,9 @@ V is either nil or non-nil."
    ("f" "Floor" calc-floor :transient nil)
    ("c" "Ceiling" calc-ceiling :transient nil)
    ("t" "Truncate" calc-trunc :transient nil)]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-conversions-menu ()
   "Casual conversion functions menu."
@@ -239,7 +245,9 @@ V is either nil or non-nil."
    ("h" "To HMS" calc-to-hms :transient nil)
    ("f" "To Fraction" calc-fraction :transient nil)
    ("F" "To Float" calc-float :transient nil)]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-time-menu ()
   "Casual time functions menu."
@@ -250,7 +258,9 @@ V is either nil or non-nil."
    ("u" "To Unix Time" calc-unix-time :transient nil)
    ("+" "Add Business Days" calc-business-days-plus :transient nil)
    ("-" "Subtract Business Days" calc-business-days-minus :transient nil)]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-first-day-menu ()
   "Casual time first day of menu."
@@ -258,7 +268,9 @@ V is either nil or non-nil."
    ("w" "Week" calc-new-week :transient nil)
    ("m" "Month" calc-new-month :transient nil)
    ("y" "Year" calc-new-year :transient nil)]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-complex-number-menu ()
   "Casual complex number functions menu."
@@ -267,7 +279,9 @@ V is either nil or non-nil."
    ("i" "Imaginary Part" calc-im :transient nil)
    ("c" "Complex Conjugate" calc-conj :transient nil)
    ("a" "Argument" calc-argument :transient nil)]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 
 (transient-define-prefix casual-random-number-menu ()
@@ -292,7 +306,9 @@ V is either nil or non-nil."
   ;;("r" "Random number within [0..𝑛)" calc-random :transient nil)
 
   [("a" "Random number again" calc-random-again :transient t)]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-binary-menu ()
   "Casual binary functions menu."
@@ -322,7 +338,9 @@ V is either nil or non-nil."
     ("w" "Set Word Size…" calc-word-size :transient nil)
     ("u" "Unpack Bits" calc-unpack-bits :transient nil)
     ("p" "Pack Bits" calc-pack-bits :transient nil)]]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-vector-menu ()
   "Casual vector and matrix functions top-level menu."
@@ -337,7 +355,9 @@ V is either nil or non-nil."
    ["Pack"
     ("p" "Pack (𝑛)" calc-pack :transient nil)
     ("u" "Unpack" calc-unpack :transient nil)]]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 ;; TODO: add Transient prefix arguments n
 (transient-define-prefix casual-vector-building-menu ()
@@ -363,7 +383,9 @@ V is either nil or non-nil."
     ("c" "Vector Count" calc-vector-count :transient nil)
     ("f" "Vector Find (𝟣:)" calc-vector-find :transient nil)
     ("h" "Histogram" calc-histogram :transient nil)]]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-vector-arithmetic-menu ()
   "Casual vector arithmetic functions menu."
@@ -379,7 +401,9 @@ V is either nil or non-nil."
     ("d" "Determinant" calc-mdet :inapt-if-not casual-square-matrixp  :transient nil)
     ("l" "LU Decomposition" calc-mlud :inapt-if-not casual-square-matrixp :transient nil)
     ("T" "Trace" calc-mtrace :inapt-if-not casual-square-matrixp :transient nil)]]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-statistics-menu ()
   "Casual statistic functions menu."
@@ -405,7 +429,9 @@ V is either nil or non-nil."
     ("5" "Covariance" calc-vector-covariance :transient nil)
     ("6" "Population Covariance" calc-vector-pop-covariance :transient nil)
     ("7" "Correlation" calc-vector-correlation :transient nil)]]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-set-operations-menu ()
   "Casual set functions menu."
@@ -417,7 +443,9 @@ V is either nil or non-nil."
     ("x" "xor" calc-set-xor :transient nil)
     ("~" "Complement" calc-set-complement :transient nil)
     ("#" "Cardinality" calc-set-cardinality :transient nil)]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-units-menu ()
   "Casual unit conversions menu."
@@ -430,7 +458,9 @@ V is either nil or non-nil."
    ("r" "Remove Units" calc-remove-units :transient nil)
    ("x" "Extract Units" calc-extract-units :transient nil)
    ("v" "View Units" calc-view-units-table :transient nil)]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-map-and-reduce-menu ()
   "Casual functional operations (map, reduce, apply) menu."
@@ -439,7 +469,9 @@ V is either nil or non-nil."
    ("r" "reduce" calc-reduce :transient nil)
    ("a" "apply" calc-apply :transient nil)
    ("A" "accumulate" calc-accumulate :transient nil)]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-logarithmic-menu ()
   "Casual logarithmic functions."
@@ -450,7 +482,9 @@ V is either nil or non-nil."
     ("L" "𝑙𝑜𝑔𝟣𝟢" calc-log10 :transient nil)
     ("M-l" "𝑙𝑜𝑔" calc-log :transient nil)
     ("M-e" "𝑒^𝑥 - 𝟣" calc-expm1 :transient nil)]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-modes-menu ()
   "Casual modes menu."
@@ -514,7 +548,9 @@ V is either nil or non-nil."
 
    ["Reset"
     ("C-M-r" "Calc Reset" calc-reset :transient t)]]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-angle-measure-menu ()
   "Casual angle measure functions menu."
@@ -525,7 +561,9 @@ V is either nil or non-nil."
    ("d" "Degrees" calc-degrees-mode :transient nil)
    ("r" "Radians" calc-radians-mode :transient nil)
    ("h" "Degrees-Minutes-Seconds" calc-hms-mode :transient nil)]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-complex-format-menu ()
   "Casual complex formats menu."
@@ -544,7 +582,9 @@ V is either nil or non-nil."
    ("j" calc-j-notation
     :description "𝑗 notation"
     :transient nil)]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-radix-menu ()
   "Casual radix functions menu."
@@ -554,7 +594,9 @@ V is either nil or non-nil."
    ("8" "Octal" calc-octal-radix :transient nil)
    ("6" "Hexadecimal" calc-hex-radix :transient nil)
    ("n" "Other base 𝑛" calc-radix :transient nil)]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-float-format-menu ()
   "Casual float formats menu."
@@ -563,7 +605,9 @@ V is either nil or non-nil."
    ("f" "Fixed Point 𝑛" calc-fix-notation :transient nil)
    ("s" "Scientific" calc-sci-notation :transient nil)
    ("e" "Engineering" calc-eng-notation :transient nil)]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
 
 (transient-define-prefix casual-trig-menu ()
   "Casual trigonometric functions menu."
@@ -585,8 +629,10 @@ V is either nil or non-nil."
                     (format "Angle Measure (now %s)›"
                             (casual-angle-mode-label)))
      :transient nil)]]
-  [("h" "Hyperbolic›" casual-hyperbolic-trig-menu :transient nil)
-   ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [("h" "Hyperbolic›" casual-hyperbolic-trig-menu :transient nil)]
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-leave)])
 
 (transient-define-prefix casual-hyperbolic-trig-menu ()
   "Casual hyperbolic trigonometric functions menu."
@@ -598,7 +644,9 @@ V is either nil or non-nil."
     ("S" "arcsinh" calc-arcsinh :transient nil)
     ("C" "arccosh" calc-arccosh :transient nil)
     ("T" "arctanh" calc-arctanh :transient nil)]]
-  [("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+  [:class transient-row
+          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
+          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-leave)])
 
 (provide 'casual)
 ;;; casual.el ends here


### PR DESCRIPTION
This adds a menu item to invoke transient--do-return for the keybinding C-g to the navigation row at the bottom of a menu to support improved discoverability.

Closes #24 