### PR TITLE
Merge development to main

### DIFF
--- a/casual.el
+++ b/casual.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual
 ;; Keywords: tools
-;; Version: 1.0.3
+;; Version: 1.0.4
 ;; Package-Requires: ((emacs "29.1"))
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/casual.el
+++ b/casual.el
@@ -159,6 +159,35 @@ V is either nil or non-nil."
   "Casual checkbox label using variable V and LABEL."
   (casual--prefix-label label (casual--variable-to-checkbox v)))
 
+;; Private functions to avoid using anonymous functions in Transients
+
+(defun casual--interactive-no-op ()
+  "No op function for Transient command."
+  (interactive))
+
+(defun casual--e-constant ()
+  "Constant 𝑒."
+  (interactive)
+  (calc-hyperbolic)
+  (calc-pi))
+
+(defun casual--stack-roll-all ()
+  "Roll entire stack."
+  (interactive)
+  (calc-roll-down (calc-stack-size)))
+
+(defun casual--stack-clear ()
+  "Clear entire stack."
+  (interactive)
+  (calc-pop-stack (calc-stack-size)))
+
+(defun casual--random-interval-0-to-m ()
+  "Generate natural random number [0..m)."
+  (interactive)
+  (let* ((m (transient-arg-value "-m=" (transient-args transient-current-command))))
+    (if m (calc-push (string-to-number m)))
+    (calc-random nil)))
+
 ;; Menus
 (transient-define-prefix casual-main-menu ()
   "Casual main menu."
@@ -175,7 +204,7 @@ V is either nil or non-nil."
     ("d" " Δ%" calc-percent-change :transient nil)]
    ["Constants"
     ("p" "𝜋" calc-pi :transient nil)
-    ("e" "𝑒" (lambda () (interactive) (calc-hyperbolic) (calc-pi)) :transient nil)]
+    ("e" "𝑒" casual--e-constant :transient nil)]
    ["Modes"
     ("m" "Modes›" casual-modes-menu :transient nil)]]
 
@@ -196,20 +225,15 @@ V is either nil or non-nil."
    ["Stack"
     :pad-keys t
     ("s" "Swap" calc-roll-down :transient t)
-    ("r" "Roll" (lambda ()
-                    (interactive) (calc-roll-down (calc-stack-size)))
-     :transient t)
-    ("C" "Clear" (lambda ()
-                   (interactive)
-                   (calc-pop-stack (calc-stack-size)))
-     :transient nil)
+    ("r" "Roll" casual--stack-roll-all :transient t)
+    ("C" "Clear" casual--stack-clear :transient nil)
     ("P" "Pack" calc-pack :transient nil)
     ("U" "Unpack" calc-unpack :transient nil)
     ("y" "Copy to Buffer" calc-copy-to-buffer :transient nil)
     ("z" "Variables›" casual-variable-crud-menu :transient nil)]]
   [:class transient-row
           ;; Note: no need to C-g for main menu
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-variable-crud-menu ()
   "Casual variable CRUD menu."
@@ -223,8 +247,8 @@ V is either nil or non-nil."
    ("p" "Persist…" calc-permanent-variable :transient t)
    ("i" "Insert variables into buffer…" calc-insert-variables :transient t)]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-rounding-menu ()
   "Casual rounding functions menu."
@@ -234,8 +258,8 @@ V is either nil or non-nil."
    ("c" "Ceiling" calc-ceiling :transient nil)
    ("t" "Truncate" calc-trunc :transient nil)]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-conversions-menu ()
   "Casual conversion functions menu."
@@ -246,8 +270,8 @@ V is either nil or non-nil."
    ("f" "To Fraction" calc-fraction :transient nil)
    ("F" "To Float" calc-float :transient nil)]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-time-menu ()
   "Casual time functions menu."
@@ -259,8 +283,8 @@ V is either nil or non-nil."
    ("+" "Add Business Days" calc-business-days-plus :transient nil)
    ("-" "Subtract Business Days" calc-business-days-minus :transient nil)]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-first-day-menu ()
   "Casual time first day of menu."
@@ -269,8 +293,8 @@ V is either nil or non-nil."
    ("m" "Month" calc-new-month :transient nil)
    ("y" "Year" calc-new-year :transient nil)]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-complex-number-menu ()
   "Casual complex number functions menu."
@@ -280,9 +304,8 @@ V is either nil or non-nil."
    ("c" "Complex Conjugate" calc-conj :transient nil)
    ("a" "Argument" calc-argument :transient nil)]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
-
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-random-number-menu ()
   "Casual random number functions menu."
@@ -291,14 +314,7 @@ V is either nil or non-nil."
    ["Natural Number"
     ("m" "𝑚" "-m=" :prompt "𝑚: "
      :reader transient-read-number-N+)
-
-    ("r" "Natural within [𝟢..𝑚)"
-     (lambda ()
-       (interactive)
-       (let* ((m (transient-arg-value "-m=" (transient-args transient-current-command))))
-         (if m (calc-push (string-to-number m)))
-         (calc-random nil)))
-     :transient t)]
+    ("r" "Natural within [𝟢..𝑚)" casual--random-interval-0-to-m :transient t)]
 
    ["Real Number"
     ("c" "Real within [𝟢.𝟢..𝟣.𝟢)" calc-rrandom :transient t)]]
@@ -307,8 +323,8 @@ V is either nil or non-nil."
 
   [("a" "Random number again" calc-random-again :transient t)]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-binary-menu ()
   "Casual binary functions menu."
@@ -339,8 +355,8 @@ V is either nil or non-nil."
     ("u" "Unpack Bits" calc-unpack-bits :transient nil)
     ("p" "Pack Bits" calc-pack-bits :transient nil)]]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-vector-menu ()
   "Casual vector and matrix functions top-level menu."
@@ -356,8 +372,8 @@ V is either nil or non-nil."
     ("p" "Pack (𝑛)" calc-pack :transient nil)
     ("u" "Unpack" calc-unpack :transient nil)]]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 ;; TODO: add Transient prefix arguments n
 (transient-define-prefix casual-vector-building-menu ()
@@ -384,8 +400,8 @@ V is either nil or non-nil."
     ("f" "Vector Find (𝟣:)" calc-vector-find :transient nil)
     ("h" "Histogram" calc-histogram :transient nil)]]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-vector-arithmetic-menu ()
   "Casual vector arithmetic functions menu."
@@ -402,8 +418,8 @@ V is either nil or non-nil."
     ("l" "LU Decomposition" calc-mlud :inapt-if-not casual-square-matrixp :transient nil)
     ("T" "Trace" calc-mtrace :inapt-if-not casual-square-matrixp :transient nil)]]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-statistics-menu ()
   "Casual statistic functions menu."
@@ -430,8 +446,8 @@ V is either nil or non-nil."
     ("6" "Population Covariance" calc-vector-pop-covariance :transient nil)
     ("7" "Correlation" calc-vector-correlation :transient nil)]]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-set-operations-menu ()
   "Casual set functions menu."
@@ -444,8 +460,8 @@ V is either nil or non-nil."
     ("~" "Complement" calc-set-complement :transient nil)
     ("#" "Cardinality" calc-set-cardinality :transient nil)]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-units-menu ()
   "Casual unit conversions menu."
@@ -459,8 +475,8 @@ V is either nil or non-nil."
    ("x" "Extract Units" calc-extract-units :transient nil)
    ("v" "View Units" calc-view-units-table :transient nil)]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-map-and-reduce-menu ()
   "Casual functional operations (map, reduce, apply) menu."
@@ -470,8 +486,8 @@ V is either nil or non-nil."
    ("a" "apply" calc-apply :transient nil)
    ("A" "accumulate" calc-accumulate :transient nil)]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-logarithmic-menu ()
   "Casual logarithmic functions."
@@ -483,8 +499,8 @@ V is either nil or non-nil."
     ("M-l" "𝑙𝑜𝑔" calc-log :transient nil)
     ("M-e" "𝑒^𝑥 - 𝟣" calc-expm1 :transient nil)]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-modes-menu ()
   "Casual modes menu."
@@ -549,8 +565,8 @@ V is either nil or non-nil."
    ["Reset"
     ("C-M-r" "Calc Reset" calc-reset :transient t)]]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-angle-measure-menu ()
   "Casual angle measure functions menu."
@@ -562,8 +578,8 @@ V is either nil or non-nil."
    ("r" "Radians" calc-radians-mode :transient nil)
    ("h" "Degrees-Minutes-Seconds" calc-hms-mode :transient nil)]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-complex-format-menu ()
   "Casual complex formats menu."
@@ -583,8 +599,8 @@ V is either nil or non-nil."
     :description "𝑗 notation"
     :transient nil)]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-radix-menu ()
   "Casual radix functions menu."
@@ -595,8 +611,8 @@ V is either nil or non-nil."
    ("6" "Hexadecimal" calc-hex-radix :transient nil)
    ("n" "Other base 𝑛" calc-radix :transient nil)]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-float-format-menu ()
   "Casual float formats menu."
@@ -606,8 +622,8 @@ V is either nil or non-nil."
    ("s" "Scientific" calc-sci-notation :transient nil)
    ("e" "Engineering" calc-eng-notation :transient nil)]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-exit)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-exit)])
 
 (transient-define-prefix casual-trig-menu ()
   "Casual trigonometric functions menu."
@@ -631,8 +647,8 @@ V is either nil or non-nil."
      :transient nil)]]
   [("h" "Hyperbolic›" casual-hyperbolic-trig-menu :transient nil)]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-leave)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-leave)])
 
 (transient-define-prefix casual-hyperbolic-trig-menu ()
   "Casual hyperbolic trigonometric functions menu."
@@ -645,8 +661,8 @@ V is either nil or non-nil."
     ("C" "arccosh" calc-arccosh :transient nil)
     ("T" "arctanh" calc-arctanh :transient nil)]]
   [:class transient-row
-          ("C-g" "‹Back" (lambda () (interactive)) :transient transient--do-return)
-          ("q" "Dismiss" (lambda () (interactive)) :transient transient--do-leave)])
+          ("C-g" "‹Back" casual--interactive-no-op :transient transient--do-return)
+          ("q" "Dismiss" casual--interactive-no-op :transient transient--do-leave)])
 
 (provide 'casual)
 ;;; casual.el ends here

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,8 +3,16 @@
 #
 
 TIMESTAMP := $(shell /bin/date "+%Y%m%d_%H%M%S")
-INSTALL_DIR=$(HOME)/bin
-EXEC_NAME=/Applications/MacPorts/EmacsMac.app/Contents/MacOS/Emacs.sh
+
+EMACS_MAC_APP_HOME=/Applications/MacPorts/EmacsMac.app
+EMACS_MAC_APP_SH=$(EMACS_MAC_APP_HOME)/Contents/MacOS/Emacs.sh
+
+ifneq ("$(wildcard $(EMACS_MAC_APP_SH))","")
+  EXEC_NAME=$(EMACS_MAC_APP_SH)
+else
+  EXEC_NAME=emacs
+endif
+
 ERT_ARGS=-batch -l ert
 EMACS=$(EXEC_NAME) $(ERT_ARGS)
 ERT_RUN=-f ert-run-tests-batch-and-exit


### PR DESCRIPTION
- **Change usage of anonymous functions in Transient prefixes**
  Prior usage of anonymous functions for commands in Transient prefixes would
  result in byte-compilation warnings. This change replaces such instances with a
  named private function.
  

- **Fix to special case install of emacs-mac-app from MacPorts.**
  

- **Bump version to 1.0.4**
  