### PR TITLE
Add menu item "Last" to main menu

### DIFF
--- a/casual.el
+++ b/casual.el
@@ -227,6 +227,7 @@ V is either nil or non-nil."
     ("s" "Swap" calc-roll-down :transient t)
     ("r" "Roll" casual--stack-roll-all :transient t)
     ("C" "Clear" casual--stack-clear :transient nil)
+    ("L" "Last" calc-last-args :transient nil)
     ("P" "Pack" calc-pack :transient nil)
     ("U" "Unpack" calc-unpack :transient nil)
     ("y" "Copy to Buffer" calc-copy-to-buffer :transient nil)

--- a/tests/test-casual.el
+++ b/tests/test-casual.el
@@ -126,6 +126,17 @@ A testcase is used as input to `casualt-menu-assert-testcase'."
      ("e" nil (float 271828182846 -11))))
   (casualt-breakdown t))
 
+(ert-deftest test-casual-main-menu-last ()
+  (casualt-setup)
+  (calc-push-list '(2 3))
+  (funcall 'casual-main-menu)
+  (execute-kbd-macro "^")
+  (funcall 'casual-main-menu)
+  (execute-kbd-macro "L")
+  (should (and (= (calc-top) 3)
+               (= (calc-top-n 2) 2)))
+  (casualt-breakdown t))
+
 (ert-deftest test-casual-rounding-menu ()
   (casualt-setup)
   (casualt-run-menu-input-testcases


### PR DESCRIPTION
This adds the menu item "Last" which is bound to calc-last-args.
This recalls the last arguments used to determine the top of the stack.
