### PR TITLE
Support for '=' bound to calc-evaluate in the main menu

### DIFF
--- a/casual.el
+++ b/casual.el
@@ -196,7 +196,8 @@ V is either nil or non-nil."
     ("&" "1/𝑥" calc-inv :transient nil)
     ("Q" " √" calc-sqrt :transient nil)
     ("n" "+∕− " calc-change-sign :transient nil)
-    ("^" "𝑦^𝑥" calc-power :transient nil)]
+    ("^" "𝑦^𝑥" calc-power :transient nil)
+    ("=" "=" calc-evaluate :transient nil)]
    [""
     ("A" "|𝑥|" calc-abs :transient nil)
     ("!" " !" calc-factorial :transient nil)

--- a/tests/test-casual.el
+++ b/tests/test-casual.el
@@ -118,6 +118,7 @@ A testcase is used as input to `casualt-menu-assert-testcase'."
      ("Q" (9) 3)
      ("n" (5) -5)
      ("^" (2 3) 8)
+     ("=" ((var pi var-pi)) (float 314159265359 -11))
      ("A" (-10) 10)
      ("!" (7) 5040)
      ("%" (8) (calcFunc-percent 8))


### PR DESCRIPTION
Adds support for calc-evaluate which will "evaluate" a formula by replacing all
variables in the formula which have been given values by a ‘calc-store’
or ‘calc-let’ command by their stored values.
