### PR TITLE
fix: Checkdoc warnings

### DIFF
--- a/lisp/casual-graphics.el
+++ b/lisp/casual-graphics.el
@@ -92,8 +92,8 @@ This can be used as a template formula to edit an order 3 polynomial."
 (defun casual--graph-refresh-plot ()
   "Internal function to refresh the Gnuplot canvas.
 This function is intended to be called after a calc-graph command
-that changes the internal state of Gnuplot is called. This way
-the canvas is updated to support interactive usage. Invokes
+that changes the internal state of Gnuplot is called.  This way
+the canvas is updated to support interactive usage.  Invokes
 `calc-graph-plot' to do the actual work."
   (call-interactively #'calc-graph-plot))
 
@@ -109,8 +109,8 @@ The y-axis specification can be either a vector or an algebraic formula with a
 single independent variable, typically 𝑥.
 
 Invoking this multiple times will for each time generate a new
-curve on the same canvas. The last curve generated is referred to
-as the current curve. The user can invoke `casual--graph-juggle'
+curve on the same canvas.  The last curve generated is referred to
+as the current curve.  The user can invoke `casual--graph-juggle'
 to rotate to an arbitrary curve to make it current.
 
 The number of sample points used to plot a curve can be set by


### PR DESCRIPTION
Fix `checkdoc` warnings:

```
`lisp/casual-graphics.el` with checkdoc (0.6.2)
casual-graphics.el:96: There should be two spaces after a period
casual-graphics.el:95: There should be two spaces after a period
casual-graphics.el:113: There should be two spaces after a period
casual-graphics.el:112: There should be two spaces after a period
```