### PR TITLE
Add missing autoload cookie for casual-main-menu

### DIFF
--- a/lisp/casual.el
+++ b/lisp/casual.el
@@ -68,6 +68,7 @@
   (calc-pop-stack (calc-stack-size)))
 
 ;; Menus
+;;;###autoload
 (transient-define-prefix casual-main-menu ()
   "Casual main menu."
   [["Calc"


### PR DESCRIPTION
It shouldn't be necessary to `require` casual ahead of running calc and triggering the casual-main-menu command.

This change means the recommended usage can simply be `(define-key calc-mode-map (kbd "C-o") 'casual-main-menu)`, assuming that `casual` has been properly installed as a package.