### PR TITLE
Fix import of versioning information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@
 
 CASUAL_LISP_DIR=./lisp
 CASUAL_EL=$(CASUAL_LISP_DIR)/casual.el
+CASUAL_VERSION_EL=$(CASUAL_LISP_DIR)/casual-version.el
 
 TIMESTAMP := $(shell /bin/date "+%Y%m%d_%H%M%S")
 CASUAL_VERSION := $(shell ./scripts/read-version.sh $(CASUAL_EL))
@@ -73,7 +74,7 @@ tests:
 ## Bump Patch Version
 bump-casual:
 	sed -i 's/;; Version: $(CASUAL_VERSION)/;; Version: $(CASUAL_VERSION_BUMP)/' $(CASUAL_EL)
-	sed -i 's/(defconst casual-version "$(CASUAL_VERSION)"/(defconst casual-version "$(CASUAL_VERSION_BUMP)"/' $(CASUAL_EL)
+	sed -i 's/(defconst casual-version "$(CASUAL_VERSION)"/(defconst casual-version "$(CASUAL_VERSION_BUMP)"/' $(CASUAL_VERSION_EL)
 
 bump: checkout-development bump-casual
 	git commit -m 'Bump version to $(CASUAL_VERSION_BUMP)' $(CASUAL_EL)

--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -25,12 +25,13 @@ else
   EXEC_NAME=emacs
 endif
 
-CASUAL_INCLUDES =					\
-casual-predicates.el					\
-casual-labels.el					\
-casual-radix.el						\
-casual-angle-measure.el					\
-casual-stack.el
+CASUAL_INCLUDES =				\
+casual-predicates.el				\
+casual-labels.el				\
+casual-radix.el					\
+casual-angle-measure.el				\
+casual-stack.el					\
+casual-version.el
 
 CASUAL_PACKAGES=				\
 casual-binary.el				\

--- a/lisp/casual-labels.el
+++ b/lisp/casual-labels.el
@@ -26,11 +26,6 @@
 (require 'calc)
 (require 'calc-math)
 
-(defun casual-version ()
-  "Show current version of Casual."
-  (interactive)
-  (message casual-version))
-
 ;; Labels
 (defun casual-cmplx-or-polar-label ()
   "Label for either complex or polar mode."

--- a/lisp/casual-settings.el
+++ b/lisp/casual-settings.el
@@ -26,6 +26,7 @@
 (require 'calc)
 (require 'transient)
 (require 'casual-labels)
+(require 'casual-version)
 (require 'casual-angle-measure)
 
 (transient-define-prefix casual-modes-menu ()
@@ -135,7 +136,7 @@
 (defun casual-about-casual ()
   "Casual is an opinionated porcelain for Emacs Calc.
 
-Casual is conceived and crafted by Charles Choi in San Francisco, California.
+Casual was conceived and crafted by Charles Choi in San Francisco, California.
 
 Learn more about using Casual at our discussion group on GitHub.
 Any questions or comments about Casual should be made there.

--- a/lisp/casual-version.el
+++ b/lisp/casual-version.el
@@ -1,0 +1,34 @@
+;;; casual-version.el --- Casual Version             -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024  Charles Choi
+
+;; Author: Charles Choi <kickingvegas@gmail.com>
+;; Keywords: tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;; Code:
+
+(defconst casual-version "1.2.2-rc.1"
+  "Casual Version.")
+
+(defun casual-version ()
+  "Show current version of Casual."
+  (interactive)
+  (message casual-version))
+
+(provide 'casual-version)
+;;; casual-version.el ends here

--- a/lisp/casual.el
+++ b/lisp/casual.el
@@ -34,6 +34,7 @@
 (require 'calc)
 (require 'calc-math) ; needed to reference some symbols not loaded in `calc'.
 (require 'transient)
+(require 'casual-version)
 (require 'casual-binary)
 (require 'casual-complex)
 (require 'casual-conversion)
@@ -49,9 +50,6 @@
 (require 'casual-trail)
 (require 'casual-stack)
 (require 'casual-financial)
-
-(defconst casual-version "1.2.2-rc.1"
-  "Casual Version.")
 
 ;; Private functions to avoid using anonymous functions in Transients
 (defun casual--e-constant ()


### PR DESCRIPTION
This change fixes byte-compilation warning that it can't find
casual-version.

Also fixes grammar in about text.
