### PR TITLE
Fix autoload to be explicit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,9 @@ create-merge-development-branch: checkout-development
 create-pr:
 	gh pr create --base development --fill
 
+create-patch-pr:
+	gh pr create --base main --fill
+
 ## Create GitHub pull request for release
 create-release-pr: create-merge-development-branch bump
 	gh pr create --base main \
@@ -119,5 +122,5 @@ create-release-tag: checkout-main
 	git tag $(CASUAL_VERSION)
 	git push origin $(CASUAL_VERSION)
 
-create-gh-release:
+create-gh-release: create-release-tag
 	gh release create -t v$(CASUAL_VERSION) --notes-from-tag $(CASUAL_VERSION)

--- a/lisp/casual-version.el
+++ b/lisp/casual-version.el
@@ -22,7 +22,7 @@
 
 ;;; Code:
 
-(defconst casual-version "1.3.0"
+(defconst casual-version "1.3.1"
   "Casual Version.")
 
 (defun casual-version ()

--- a/lisp/casual.el
+++ b/lisp/casual.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual
 ;; Keywords: tools
-;; Version: 1.3.0
+;; Version: 1.3.1
 ;; Package-Requires: ((emacs "29.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -69,7 +69,7 @@
   (calc-pop-stack (calc-stack-size)))
 
 ;; Menus
-;;;###autoload
+;;;###autoload (autoload 'casual-main-menu "casual" nil t)
 (transient-define-prefix casual-main-menu ()
   "Casual main menu."
   [["Calc"


### PR DESCRIPTION
Change autoload to be explicit to support install by DOOM Emacs and other
package managers.

This patch driven by discussion in
https://github.com/kickingvegas/Casual/discussions/99

Bump to 1.3.1.

Update Makefile targets to support patching and streamline making a release.
