### PR TITLE
Support for customizing calc-kill-line-numbering

### DIFF
--- a/lisp/casual-stack.el
+++ b/lisp/casual-stack.el
@@ -26,28 +26,36 @@
 (require 'calc)
 (require 'transient)
 
+(defun casual-customize-kill-line-numbering ()
+  "Customize Calc kill line numbering behavior.
+Customize the variable `calc-kill-line-numbering'.
+Set `calc-kill-line-numbering' to nil to exclude line numbering
+from kill-ring operations."
+  (interactive)
+  (customize-variable 'calc-kill-line-numbering))
+
 (transient-define-prefix casual-stack-display-menu ()
   "Casual stack display menu."
   ["Justification"
    :class transient-row
    ("l" "Left" calc-left-justify :transient t)
    ("c" "Center" calc-center-justify :transient t)
-   ("r" "Right" calc-right-justify :transient t)
-   ]
+   ("r" "Right" calc-right-justify :transient t)]
 
   [["Truncation"
     ("." "At Point" calc-truncate-stack :transient t)
     ("p" "Previous" calc-truncate-up :transient t)
-    ("n" "Next" calc-truncate-down :transient t)
-    ]
+    ("n" "Next" calc-truncate-down :transient t)]
 
    ["Misc"
     ("R" "Refresh" calc-refresh :transient t)
-    ]]
-  [:class transient-row
-          ("C-g" "‹Back" ignore :transient transient--do-return)
-          ("q" "Dismiss" ignore :transient transient--do-exit)
-          ("s" "Save Settings" calc-save-modes :transient t)])
+    ("l" "Customize kill line numbering"
+     casual-customize-kill-line-numbering :transient nil)]]
+  [""
+   :class transient-row
+   ("C-g" "‹Back" ignore :transient transient--do-return)
+   ("q" "Dismiss" ignore :transient transient--do-exit)
+   ("s" "Save Settings" calc-save-modes :transient t)])
 
 (provide 'casual-stack)
 ;;; casual-stack.el ends here

--- a/lisp/casual.el
+++ b/lisp/casual.el
@@ -51,23 +51,6 @@
 (require 'casual-stack)
 (require 'casual-financial)
 
-;; Private functions to avoid using anonymous functions in Transients
-(defun casual--e-constant ()
-  "Constant 𝑒."
-  (interactive)
-  (calc-hyperbolic)
-  (calc-pi))
-
-(defun casual--stack-roll-all ()
-  "Roll entire stack."
-  (interactive)
-  (calc-roll-down (calc-stack-size)))
-
-(defun casual--stack-clear ()
-  "Clear entire stack."
-  (interactive)
-  (calc-pop-stack (calc-stack-size)))
-
 ;; Menus
 ;;;###autoload (autoload 'casual-main-menu "casual" nil t)
 (transient-define-prefix casual-main-menu ()
@@ -116,7 +99,7 @@
     ("d" "Drop" calc-pop :transient t)
     ("C" "Clear" casual--stack-clear :transient t)
     ("L" "Last" calc-last-args :transient t)
-    ("y" "Copy to Buffer" calc-copy-to-buffer :transient nil)
+    ("w" "Copy as kill" casual-calc-copy-as-kill :transient nil)
     ("z" "Variables›" casual-variable-crud-menu :transient nil)]]
   [:class transient-row
           ;; Note: no need to C-g for main menu
@@ -138,6 +121,38 @@
           ("C-g" "‹Back" ignore :transient transient--do-return)
           ("q" "Dismiss" ignore :transient transient--do-exit)
           ("U" "Undo Stack" calc-undo :transient t)])
+
+;; Wrapped Functions
+(defun casual--e-constant ()
+  "Constant 𝑒."
+  (interactive)
+  (calc-hyperbolic)
+  (calc-pi))
+
+(defun casual--stack-roll-all ()
+  "Roll entire stack."
+  (interactive)
+  (calc-roll-down (calc-stack-size)))
+
+(defun casual--stack-clear ()
+  "Clear entire stack."
+  (interactive)
+  (calc-pop-stack (calc-stack-size)))
+
+(defun casual-calc-copy-as-kill ()
+  "Copy top of stack (1:) to kill ring.
+\nBy default, Calc will include the stack line number to kill-ring operations.
+To _not_ do this, set `calc-kill-line-numbering' to nil.
+\nStack Arguments:
+1: n
+
+This function wraps over `calc-copy-as-kill'.
+
+* References
+- info node `(calc) 14.1 Killing from the Stack'
+- `calc-copy-as-kill'"
+  (interactive)
+  (call-interactively #'calc-copy-as-kill))
 
 (provide 'casual)
 ;;; casual.el ends here


### PR DESCRIPTION
Adds support for customizing the variable calc-kill-line-numbering which sets
the behavior of including line numbering from the stack when performing
kill-ring operations on stack values.

- Customizing this value is done from casual-stack-display-menu.
- UI change to casual-main-menu
  - Replace calc-copy-to-buffer with calc-copy-as-kill
