### PR TITLE
Wrap Calc Functions in Main Menu to support Transient Help

### DIFF
--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -26,6 +26,7 @@ else
 endif
 
 CASUAL_INCLUDES =				\
+casual-calc.el					\
 casual-predicates.el				\
 casual-labels.el				\
 casual-radix.el					\

--- a/lisp/casual-calc.el
+++ b/lisp/casual-calc.el
@@ -1,0 +1,315 @@
+;;; casual-calc.el --- Casual Wrapped Calc Functions  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024  Charles Choi
+
+;; Author: Charles Choi <kickingvegas@gmail.com>
+;; Keywords: tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;
+
+;;; Code:
+(require 'calc)
+(require 'calc-math)
+
+;; Wrapped Functions
+;; Shortdoc
+;;(define-short-documentation-group casual "Casual Shortdoc")
+;;(shortdoc-add-function 'casual "Constants" '(casual-calc-pi :no-manual))
+
+(defun casual-calc-pi ()
+  "Push the value of 𝜋 at the current precision onto the stack.
+\nIf in symbolic mode, this command instead pushes the actual
+variable \\='pi\\='.
+
+This function is a wrapper over `calc-pi'.
+
+* References
+- info node `(calc) Scientific Functions'
+- `calc-pi'"
+  (interactive)
+  (call-interactively #'calc-pi))
+
+(defun casual--e-constant ()
+  "Constant 𝑒.
+\nIf in symbolic mode, this command instead pushes the actual
+variable \\='e\\='.
+
+This function is a wrapper over `calc-pi'.
+
+* References
+- info node `(calc) Scientific Functions'
+- `calc-pi'"
+  (interactive)
+  ;; !!!: Do not use this function in persisted Transient.
+  (calc-hyperbolic)
+  (calc-pi))
+
+
+(defun casual-calc-inv ()
+  "Invert the value n at the top of the stack.
+\nIf n is a number, then compute its reciprocal. If n is a square
+matrix, then compute the inverse of the matrix.
+\nStack Arguments:
+1: n
+
+This function is a wrapper over `calc-inv'.
+
+* References
+- info node `(calc) Basic Arithmetic'
+- `calc-inv'"
+  (interactive)
+  (call-interactively #'calc-inv))
+
+(defun casual-calc-sqrt ()
+  "Compute the square root of a number.
+\nFor a negative real argument, the result will be a complex
+number whose form is determined by the current Polar mode.
+\nStack Arguments:
+1: n
+
+This function is a wrapper over `calc-sqrt'.
+
+* References
+- info node `(calc) Basic Arithmetic'
+- `calc-sqrt'"
+  (interactive)
+  (call-interactively #'calc-sqrt))
+
+(defun casual-calc-change-sign ()
+  "Negate the number on the top of the stack.
+\nThis works on numbers, vectors and matrices, HMS forms, date
+forms, error forms, intervals, and modulo forms.
+
+\nStack Arguments:
+1: n
+
+This function is a wrapper over `calc-change-sign'.
+
+* References
+- info node `(calc) Basic Arithmetic'
+- `calc-change-sign'"
+  (interactive)
+  (call-interactively #'calc-change-sign))
+
+(defun casual-calc-power ()
+  "Raise a number 𝑦 to a power 𝑥.
+\nIf the power is an integer, an exact result is computed using
+repeated multiplications. For non-integer powers, Calc uses
+Newton's method or logarithms and exponentials. Square matrices
+can be raised to integer powers. If either argument is an
+error (or interval or modulo) form, the result is also an
+error (or interval or modulo) form.
+\nStack Arguments:
+2: 𝑦
+1: 𝑥
+
+This function is a wrapper over `calc-power'.
+
+* References
+- info node `(calc) Basic Arithmetic'
+- `calc-power'"
+  (interactive)
+  (call-interactively #'calc-power))
+
+(defun casual-calc-abs ()
+  "Compute the absolute value of a number.
+\nThe result is always a nonnegative real number: With a complex
+argument, it computes the complex magnitude. With a vector or
+matrix argument, it computes the Frobenius norm, i.e., the square
+root of the sum of the squares of the absolute values of the
+elements. The absolute value of an error form is defined by
+replacing the mean part with its absolute value and leaving the
+error part the same. The absolute value of a modulo form is
+undefined. The absolute value of an interval is defined in the
+obvious way.
+\nStack Arguments: 1: n
+
+This function is a wrapper over `calc-abs'.
+
+* References
+- info node `(calc) Basic Arithmetic'
+- `calc-abs'"
+  (interactive)
+  (call-interactively #'calc-abs))
+
+
+(defun casual-calc-factorial ()
+  "Compute the factorial of the number at the top of the stack.
+\nIf the number is an integer, the result is an exact integer. If
+the number is an integer-valued float, the result is a
+floating-point approximation. If the number is a non-integral
+real number, the generalized factorial is used, as defined by the
+Euler Gamma function. Please note that computation of large
+factorials can be slow; using floating-point format will help
+since fewer digits must be maintained.
+
+\nStack Arguments:
+1: n
+
+This function is a wrapper over `calc-factorial'.
+
+* References
+- info node `(calc) Combinatorial Functions'
+- `calc-factorial'"
+  (interactive)
+  (call-interactively #'calc-factorial))
+
+(defun casual-calc-percent ()
+  "Convert top of the stack into a percentage formula where the '%' is appended.
+\nThe '%' operator means “the preceding value divided by 100”.
+
+\nStack Arguments:
+1: n
+
+This function is a wrapper over `calc-percent'.
+
+* References
+- info node `(calc) Percentages'
+- `calc-percent'"
+  (interactive)
+  (call-interactively #'calc-percent))
+
+(defun casual-calc-percent-change ()
+  "Calculate the percentage change from one number to another.
+\nCalculates the percentage change from a previous value (p) to a
+current value (c).
+\nStack Arguments:
+2: p
+1: c
+
+This function is a wrapper over `calc-percent-change'.
+
+* References
+- info node `(calc) Percentages'
+- `calc-percent-change'"
+  (interactive)
+  (call-interactively #'calc-percent-change))
+
+(defun casual-calc-evaluate ()
+  "Evaluate a formula by replacing all variables with their stored values.
+\nIf a variable in the formula does not have a stored value, it is left alone.
+\nStack Arguments:
+1: n
+
+This function is a wrapper over `calc-evaluate'.
+
+* References
+- info node `(calc) Variables'
+- `calc-evaluate'"
+  (interactive)
+  (call-interactively #'calc-evaluate))
+
+(defun casual-calc-store ()
+  "Store the value at the top of the stack into a specified variable.
+\nStack Arguments:
+1: n
+
+This function is a wrapper over `calc-store'.
+
+* References
+- info node `(calc) Storing Variables'
+- `calc-store'"
+  (interactive)
+  (call-interactively #'calc-store))
+
+(defun casual-calc-recall ()
+  "Recall a stored variable.
+\nThis command prompts for a variable name that was stored
+using `casual-calc-store'.
+\nThis function is a wrapper over `calc-recall'.
+
+* References
+- info node `(calc) Recalling Variables'
+- `calc-recall'"
+  (interactive)
+  (call-interactively #'calc-recall))
+
+(defun casual-calc-unstore ()
+  "Unstore (clears) a stored variable.
+\nComplimentary command to `casual-calc-store'.
+\nThis function is a wrapper over `calc-unstore'.
+
+* References
+- info node `(calc) Storing Variables'
+- `calc-unstore'"
+  (interactive)
+  (call-interactively #'calc-unstore))
+
+(defun casual-calc-edit-variable ()
+  "Edits the stored value of a variable.
+\nThe value of the stored variable is modified without putting
+the value on the stack or simplifying or evaluating the value.
+This command will prompt for the name of the variable to edit.
+\nThis function is a wrapper over `calc-edit-variable'.
+
+* References
+- info node `(calc) Operations on Variables'
+- `calc-edit-variable'"
+  (interactive)
+  (call-interactively #'calc-edit-variable))
+
+(defun casual-calc-copy-variable ()
+  "Copies the stored value of one variable to another.
+\nThis function is a wrapper over `calc-copy-variable'.
+
+* References
+- info node `(calc) Storing Variables'
+- `calc-copy-variable'"
+  (interactive)
+  (call-interactively #'calc-copy-variable))
+
+(defun casual-calc-store-exchange ()
+  "Exchanges the value of a stored variable with the top of the stack.
+\nStack Arguments:
+1: n
+
+This function is a wrapper over `calc-store-exchange'.
+
+* References
+- info node `(calc) Storing Variables'
+- `calc-store-exchange'"
+  (interactive)
+  (call-interactively #'calc-store-exchange))
+
+(defun casual-calc-permanent-variable ()
+  "Persist a stored variable so that it is available across restarts of Emacs.
+\nTypically file stored variables are persisted to is
+‘~/<emacs config path>/calc.el’.
+To remove a persisted stored variable, one must edit this file.
+\nThis function is a wrapper over `calc-permanent-variable'.
+
+* References
+- info node `(calc) Operations on Variables'
+- `calc-permanent-variable'"
+  (interactive)
+  (call-interactively #'calc-permanent-variable))
+
+(defun casual-calc-insert-variables ()
+  "Write all stored variables into a specified buffer.
+\nThe variables are written with the prefix ‘var-’ in the form of
+Lisp ‘setq’ commands which store the values in string form.
+\nThis function is a wrapper over `calc-insert-variables'.
+
+* References
+- info node `(calc) Operations on Variables'
+- `calc-insert-variables'"
+  (interactive)
+  (call-interactively #'calc-insert-variables))
+
+(provide 'casual-calc)
+;;; casual-calc.el ends here

--- a/lisp/casual-stack.el
+++ b/lisp/casual-stack.el
@@ -24,13 +24,15 @@
 
 ;;; Code:
 (require 'calc)
+(require 'calc-yank)
+(require 'calc-undo)
 (require 'transient)
 
 (defun casual-customize-kill-line-numbering ()
   "Customize Calc kill line numbering behavior.
 Customize the variable `calc-kill-line-numbering'.
 Set `calc-kill-line-numbering' to nil to exclude line numbering
-from kill-ring operations."
+from `kill-ring' operations."
   (interactive)
   (customize-variable 'calc-kill-line-numbering))
 
@@ -56,6 +58,77 @@ from kill-ring operations."
    ("C-g" "‹Back" ignore :transient transient--do-return)
    ("q" "Dismiss" ignore :transient transient--do-exit)
    ("s" "Save Settings" calc-save-modes :transient t)])
+
+
+;; Wrapped Functions
+(defun casual--stack-roll-all ()
+  "Roll down stack accounting for all elements currently on the stack.
+
+* References
+- info node `(calc) Stack Manipulation'
+- `calc-roll-down'"
+  (interactive)
+  (calc-roll-down (calc-stack-size)))
+
+(defun casual--stack-clear ()
+  "Clear entire stack."
+  (interactive)
+  (calc-pop-stack (calc-stack-size)))
+
+(defun casual--stack-swap ()
+  "Exchange the top two elements of the stack.
+\nGiven the values a in (2:) and b in (1:), performing this command will
+exchange their places resulting with b in (2:) and a in (1:).
+\nStack Arguments:
+2: a
+1: b
+
+This function is a wrapper over `calc-roll-down'.
+
+* References
+- info node `(calc) Stack Manipulation'
+- `calc-roll-down'"
+  (interactive)
+  (call-interactively #'calc-roll-down))
+
+(defun casual--stack-drop ()
+  "Remove the top element of the stack.
+\nStack Arguments:
+1: n
+
+This function is a wrapper over `calc-pop'.
+
+* References
+- info node `(calc) Stack Manipulation'
+- `calc-pop'"
+  (interactive)
+  (call-interactively #'calc-pop))
+
+(defun casual--stack-last ()
+  "Push the last arguments popped by the previous command back onto the stack.
+\nThis function is a wrapper over `calc-last-args'.
+
+* References
+- info node `(calc) Keep Arguments'
+- `calc-last-args'"
+  (interactive)
+  (call-interactively #'calc-last-args))
+
+
+(defun casual-calc-copy-as-kill ()
+  "Copy top of stack (1:) to the clip-ring (aka `kill-ring').
+\nBy default, Calc will include the stack line number to clip-ring operations.
+To _not_ do this, set `calc-kill-line-numbering' to nil.
+\nStack Arguments:
+1: n
+
+This function wraps over `calc-copy-as-kill'.
+
+* References
+- info node `(calc) Killing from Stack'
+- `calc-copy-as-kill'"
+  (interactive)
+  (call-interactively #'calc-copy-as-kill))
 
 (provide 'casual-stack)
 ;;; casual-stack.el ends here

--- a/lisp/casual.el
+++ b/lisp/casual.el
@@ -34,6 +34,7 @@
 (require 'calc)
 (require 'calc-math) ; needed to reference some symbols not loaded in `calc'.
 (require 'transient)
+(require 'casual-calc)
 (require 'casual-version)
 (require 'casual-binary)
 (require 'casual-complex)
@@ -55,20 +56,20 @@
 ;;;###autoload (autoload 'casual-main-menu "casual" nil t)
 (transient-define-prefix casual-main-menu ()
   "Casual main menu."
-  [["Calc"
+  [["Casual"
     :pad-keys t
-    ("&" "1/𝑥" calc-inv :transient nil)
-    ("Q" " √" calc-sqrt :transient nil)
-    ("n" "+∕− " calc-change-sign :transient nil)
-    ("^" "𝑦^𝑥" calc-power :transient nil)
-    ("=" " =" calc-evaluate :transient nil)]
+    ("&" "1/𝑥" casual-calc-inv :transient nil)
+    ("Q" " √" casual-calc-sqrt :transient nil)
+    ("n" "+∕− " casual-calc-change-sign :transient nil)
+    ("^" "𝑦^𝑥" casual-calc-power :transient nil)
+    ("=" " =" casual-calc-evaluate :transient nil)]
    [""
-    ("A" "|𝑥|" calc-abs :transient nil)
-    ("!" " !" calc-factorial :transient nil)
-    ("%" " ٪" calc-percent :transient nil)
-    ("D" " Δ%" calc-percent-change :transient nil)]
+    ("A" "|𝑥|" casual-calc-abs :transient nil)
+    ("!" " !" casual-calc-factorial :transient nil)
+    ("%" " ٪" casual-calc-percent :transient nil)
+    ("D" " Δ%" casual-calc-percent-change :transient nil)]
    ["Constants"
-    ("p" "𝜋" calc-pi :transient nil)
+    ("p" "𝜋" casual-calc-pi :transient nil)
     ("e" "𝑒" casual--e-constant :transient nil)]
    ["Settings"
     :pad-keys t
@@ -94,12 +95,12 @@
     ("g" "Graphics›" casual-plot-menu :transient nil)]
    ["Stack"
     :pad-keys t
-    ("s" "Swap" calc-roll-down :transient t)
+    ("s" "Swap" casual--stack-swap :transient t)
     ("r" "Roll" casual--stack-roll-all :transient t)
-    ("d" "Drop" calc-pop :transient t)
+    ("d" "Drop" casual--stack-drop :transient t)
     ("C" "Clear" casual--stack-clear :transient t)
-    ("L" "Last" calc-last-args :transient t)
-    ("w" "Copy as kill" casual-calc-copy-as-kill :transient nil)
+    ("L" "Last" casual--stack-last :transient t)
+    ("w" "Copy" casual-calc-copy-as-kill :transient nil)
     ("z" "Variables›" casual-variable-crud-menu :transient nil)]]
   [:class transient-row
           ;; Note: no need to C-g for main menu
@@ -107,52 +108,22 @@
           ("U" "Undo Stack" calc-undo :transient t)])
 
 (transient-define-prefix casual-variable-crud-menu ()
-  "Casual variable CRUD menu."
+  "Stored variable operations menu.
+Operations to store, recall, clear, and edit variables are provided by this
+menu."
   ["Variable Operations"
-   ("s" "Store (𝟣:)…" calc-store :transient t)
-   ("r" "Recall…" calc-recall :transient t)
-   ("c" "Clear…" calc-unstore :transient t)
-   ("e" "Edit…" calc-edit-variable :transient nil)
-   ("o" "Copy to other variable…" calc-copy-variable :transient t)
-   ("x" "Exchange (𝟣:) to variable…" calc-store-exchange :transient t)
-   ("p" "Persist…" calc-permanent-variable :transient t)
-   ("i" "Insert variables into buffer…" calc-insert-variables :transient t)]
+   ("s" "Store (𝟣:)…" casual-calc-store :transient t)
+   ("r" "Recall…" casual-calc-recall :transient t)
+   ("c" "Clear…" casual-calc-unstore :transient t)
+   ("e" "Edit…" casual-calc-edit-variable :transient nil)
+   ("o" "Copy to other variable…" casual-calc-copy-variable :transient t)
+   ("x" "Exchange (𝟣:) to variable…" casual-calc-store-exchange :transient t)
+   ("p" "Persist…" casual-calc-permanent-variable :transient t)
+   ("i" "Insert variables into buffer…" casual-calc-insert-variables :transient t)]
   [:class transient-row
           ("C-g" "‹Back" ignore :transient transient--do-return)
           ("q" "Dismiss" ignore :transient transient--do-exit)
           ("U" "Undo Stack" calc-undo :transient t)])
-
-;; Wrapped Functions
-(defun casual--e-constant ()
-  "Constant 𝑒."
-  (interactive)
-  (calc-hyperbolic)
-  (calc-pi))
-
-(defun casual--stack-roll-all ()
-  "Roll entire stack."
-  (interactive)
-  (calc-roll-down (calc-stack-size)))
-
-(defun casual--stack-clear ()
-  "Clear entire stack."
-  (interactive)
-  (calc-pop-stack (calc-stack-size)))
-
-(defun casual-calc-copy-as-kill ()
-  "Copy top of stack (1:) to kill ring.
-\nBy default, Calc will include the stack line number to kill-ring operations.
-To _not_ do this, set `calc-kill-line-numbering' to nil.
-\nStack Arguments:
-1: n
-
-This function wraps over `calc-copy-as-kill'.
-
-* References
-- info node `(calc) 14.1 Killing from the Stack'
-- `calc-copy-as-kill'"
-  (interactive)
-  (call-interactively #'calc-copy-as-kill))
 
 (provide 'casual)
 ;;; casual.el ends here

--- a/tests/test-casual-calc.el
+++ b/tests/test-casual-calc.el
@@ -1,0 +1,145 @@
+;;; test-casual-calc.el --- Casual Wrapped Casual Tests  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024  Charles Choi
+
+;; Author: Charles Choi <kickingvegas@gmail.com>
+;; Keywords: tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;
+
+;;; Code:
+(require 'ert)
+(require 'casual)
+(require 'casual-test-utils)
+(require 'casual-calc)
+
+;;; Tests
+
+(ert-deftest test-casual-calc-inv ()
+  (casualt-setup)
+  (calc-push 10)
+  (casualt-testbench-calc-fn #'casual-calc-inv
+                             '()
+                             '(float 1 -1))
+  (casualt-breakdown t))
+
+
+(ert-deftest test-casual-calc-sqrt ()
+  (casualt-setup)
+  (calc-push 25)
+  (casualt-testbench-calc-fn #'casual-calc-sqrt
+                             '()
+                             5)
+  (casualt-breakdown t))
+
+(ert-deftest test-casual-calc-change-sign ()
+  (casualt-setup)
+  (calc-push 10)
+  (casualt-testbench-calc-fn #'casual-calc-change-sign
+                             '()
+                             -10)
+  (casualt-breakdown t))
+
+
+(ert-deftest test-casual-calc-power ()
+  (casualt-setup)
+  (calc-push 2)
+  (calc-push 3)
+  (casualt-testbench-calc-fn #'casual-calc-power
+                             '()
+                             8)
+  (casualt-breakdown t))
+
+
+(ert-deftest test-casual-calc-abs ()
+  (casualt-setup)
+  (calc-push -10)
+  (casualt-testbench-calc-fn #'casual-calc-abs
+                             '()
+                             10)
+  (casualt-breakdown t))
+
+(ert-deftest test-casual-calc-factorial ()
+  (casualt-setup)
+  (calc-push 10)
+  (casualt-testbench-calc-fn #'casual-calc-factorial
+                             '()
+                             3628800)
+  (casualt-breakdown t))
+
+(ert-deftest test-casual-calc-percent ()
+  (casualt-setup)
+  (calc-push 10)
+  (casualt-testbench-calc-fn #'casual-calc-percent
+                             '()
+                             '(calcFunc-percent 10))
+  (casualt-breakdown t))
+
+(ert-deftest test-casual-calc-percent-change ()
+  (casualt-setup)
+  (calc-push 40)
+  (calc-push 50)
+  (casualt-testbench-calc-fn #'casual-calc-percent-change
+                             '()
+                             '(calcFunc-percent 25))
+  (casualt-breakdown t))
+
+(ert-deftest test-casual-calc-pi ()
+  (casualt-setup)
+  (casualt-testbench-calc-fn #'casual-calc-pi
+                             '()
+                             '(float 314159265359 -11))
+  (casualt-breakdown t))
+
+(ert-deftest test-casual-calc-evaluate ()
+  (casualt-setup)
+  (calc-push '(* 10 (var x var-x)))
+  (casualt-testbench-calc-fn #'casual-calc-evaluate
+                             '()
+                             '(* 10 (var x var-x)))
+  (casualt-breakdown t))
+
+(ert-deftest test-casual--stack-swap ()
+  (casualt-setup)
+  (calc-push 10)
+  (calc-push 20)
+  (casualt-testbench-calc-fn #'casual--stack-swap
+                             '()
+                             10)
+  (casualt-breakdown t))
+
+(ert-deftest test-casual--stack-drop ()
+  (casualt-setup)
+  (calc-push 19)
+  (calc-push 20)
+  (casualt-testbench-calc-fn #'casual--stack-drop
+                             '()
+                             19)
+  (casualt-breakdown t))
+
+(ert-deftest test-casual--stack-last ()
+  (casualt-setup)
+  (calc-push 225)
+  (call-interactively #'calc-pop)
+  (casualt-testbench-calc-fn #'casual--stack-last
+                             '()
+                             225)
+  (casualt-breakdown t))
+
+(provide 'test-casual-calc)
+;;; test-casual-calc.el ends here

--- a/tests/test-casual.el
+++ b/tests/test-casual.el
@@ -50,19 +50,42 @@
 
 (ert-deftest test-casual-main-menu ()
   (casualt-setup)
-  (casualt-run-menu-input-testcases
-   'casual-main-menu
-   '(("&" (2) (float 5 -1))
-     ("Q" (9) 3)
-     ("n" (5) -5)
-     ("^" (2 3) 8)
-     ("=" ((var pi var-pi)) (float 314159265359 -11))
-     ("A" (-10) 10)
-     ("!" (7) 5040)
-     ("%" (8) (calcFunc-percent 8))
-     ("D" (100 20) (calcFunc-percent -80))
-     ("p" nil (float 314159265359 -11))
-     ("e" nil (float 271828182846 -11))))
+  (let ((test-vectors '(("&" . casual-calc-inv)
+                        ("Q" . casual-calc-sqrt)
+                        ("n" . casual-calc-change-sign)
+                        ("^" . casual-calc-power)
+                        ("=" . casual-calc-evaluate)
+                        ("A" . casual-calc-abs)
+                        ("!" . casual-calc-factorial)
+                        ("%" . casual-calc-percent)
+                        ("D" . casual-calc-percent-change)
+                        ("p" . casual-calc-pi)
+                        ("e" . casual--e-constant)
+                        ("m" . casual-modes-menu)
+                        ("ó" . casual-stack-display-menu)
+                        ("ô" . casual-trail-menu)
+                        ("o" . casual-rounding-menu)
+                        ("c" . casual-conversions-menu)
+                        ("T" . casual-time-menu)
+                        ("i" . casual-complex-number-menu)
+                        ("a" . casual-random-number-menu)
+                        ("t" . casual-trig-menu)
+                        ("l" . casual-logarithmic-menu)
+                        ("b" . casual-binary-menu)
+                        ("v" . casual-vector-menu)
+                        ("u" . casual-units-menu)
+                        ("f" . casual-financial-menu)
+                        ("g" . casual-plot-menu)
+                        ("s" . casual--stack-swap)
+                        ("r" . casual--stack-roll-all)
+                        ("d" . casual--stack-drop)
+                        ("C" . casual--stack-clear)
+                        ("L" . casual--stack-last)
+                        ("w" . casual-calc-copy-as-kill)
+                        ("z" . casual-variable-crud-menu))))
+    (casualt-suffix-testbench-runner test-vectors
+                                     #'casual-main-menu
+                                     '(lambda () (random 5000))))
   (casualt-breakdown t))
 
 (ert-deftest test-casual-main-menu-last ()
@@ -107,6 +130,22 @@
   ;; TODO: punting on calc-permanent-variable
   ;; TODO: punting on calc-insert-variables
   (casualt-breakdown t))
+
+(ert-deftest test-casual-variable-crud-menu2 ()
+  (casualt-setup)
+  (let ((test-vectors '(("sq" . casual-calc-store)
+                        ("rq" . casual-calc-recall)
+                        ("cq" . casual-calc-unstore)
+                        ("e" . casual-calc-edit-variable)
+                        ("oq" . casual-calc-copy-variable)
+                        ("xq" . casual-calc-store-exchange)
+                        ("pq" . casual-calc-permanent-variable)
+                        ("iq" . casual-calc-insert-variables))))
+    (casualt-suffix-testbench-runner test-vectors
+                                     #'casual-variable-crud-menu
+                                     '(lambda () (random 5000))))
+  (casualt-breakdown t))
+
 
 (provide 'test-casual)
 ;;; test-casual.el ends here


### PR DESCRIPTION
Adds wrappers to Calc functions called by the Casual main menu so that they can
have docstrings which can be accessed via the Transient help system.

Another benefit is that said wrappers can be mocked for unit testing of
Transient menus.
