### PR TITLE
Tune binary menu UX

### DIFF
--- a/lisp/casual-calc-binary.el
+++ b/lisp/casual-calc-binary.el
@@ -32,34 +32,232 @@
   "Casual binary functions menu."
   ["Binary Functions"
    ["Operators"
-    ("a" "and" calc-and :transient nil)
-    ("o" "or" calc-or :transient nil)
-    ("x" "xor" calc-xor :transient nil)
-    ("-" "diff" calc-diff :transient nil)
-    ("!" "not" calc-not :transient nil)]
+    ("a" "and" casual-calc--calc-and :transient nil)
+    ("o" "or" casual-calc--calc-or :transient nil)
+    ("x" "xor" casual-calc--calc-xor :transient nil)
+    ("-" "diff" casual-calc--calc-diff :transient nil)
+    ("!" "not" casual-calc--calc-not :transient nil)]
    ["Shift"
     :pad-keys t
-    ("l" "binary left" calc-lshift-binary :transient t)
-    ("r" "binary right" calc-rshift-binary :transient t)
-    ("M-l" "arithmetic left" calc-lshift-arith :transient t)
-    ("M-r" "arithmetic right" calc-rshift-arith :transient t)
-    ("C-r" "rotate binary" calc-rotate-binary :transient t)]
+    ("l" "binary left" casual-calc--calc-lshift-binary :transient t)
+    ("r" "binary right" casual-calc--calc-rshift-binary :transient t)
+    ("M-l" "arithmetic left" casual-calc--calc-lshift-arith :transient t)
+    ("M-r" "arithmetic right" casual-calc--calc-rshift-arith :transient t)
+    ("C-r" "rotate binary" casual-calc--calc-rotate-binary :transient t)]
    ["Utils"
     ("R" casual-calc-radix-tmenu
      :description (lambda ()
                     (format "Radix (now %s)›" (casual-calc-number-radix-label)))
-     :transient nil)
+     :transient t)
     ("z" "Leading Zeroes" calc-leading-zeros
      :description (lambda ()
                     (casual-calc--checkbox-label calc-leading-zeros "Leading Zeroes"))
-     :transient nil)
-    ("w" "Set Word Size…" calc-word-size :transient nil)
-    ("u" "Unpack Bits" calc-unpack-bits :transient nil)
-    ("p" "Pack Bits" calc-pack-bits :transient nil)]]
+     :transient t)
+    ("," "Thousands Separator…" calc-group-char
+     :description (lambda ()
+                    (format "Set Thousands Separator (now %s)…" calc-group-char))
+     :transient t)
+    ("w" "Set Word Size…" casual-calc--calc-word-size :transient t)
+    ("u" "Unpack Bits" casual-calc--calc-unpack-bits :transient nil)
+    ("p" "Pack Bits" casual-calc--calc-pack-bits :transient nil)]]
   [:class transient-row
           ("C-g" "‹Back" ignore :transient transient--do-return)
           ("q" "Dismiss" ignore :transient transient--do-exit)
           ("U" "Undo Stack" calc-undo :transient t)])
+
+
+;; Wrapped Calc Functions
+
+(defun casual-calc--calc-and ()
+  "Computes the bitwise AND of the two numbers on the top of the stack.
+\nStack Arguments:
+2: a
+1: b
+
+This function is a wrapper over `calc-and'.
+
+* References
+- info node `(calc) Binary Functions'
+- `calc-and'"
+ (interactive)
+ (call-interactively #'calc-and))
+
+(defun casual-calc--calc-or ()
+  "Computes the bitwise inclusive OR of two numbers.
+\nStack Arguments:
+2: a
+1: b
+
+This function is a wrapper over `calc-or'.
+
+* References
+- info node `(calc) Binary Functions'
+- `calc-or'"
+ (interactive)
+ (call-interactively #'calc-or))
+
+(defun casual-calc--calc-xor ()
+  "Computes the bitwise exclusive OR of two numbers.
+\nStack Arguments:
+2: a
+1: b
+
+This function is a wrapper over `calc-xor'.
+
+* References
+- info node `(calc) Binary Functions'
+- `calc-xor'"
+ (interactive)
+ (call-interactively #'calc-xor))
+
+(defun casual-calc--calc-diff ()
+  "Computes the bitwise difference of two numbers.
+\nStack Arguments:
+2: a
+1: b
+
+This is defined by ‘diff(a,b) = and(a,not(b))’, so that
+‘diff(2#1100, 2#1010) = 2#0100’.
+
+This function is a wrapper over `calc-diff'.
+
+* References
+- info node `(calc) Binary Functions'
+- `calc-diff'"
+ (interactive)
+ (call-interactively #'calc-diff))
+
+(defun casual-calc--calc-not ()
+  "Computes the bitwise NOT of a number.
+\nStack Arguments:
+1: n
+
+A bit is 1 if the input bit is 0 and vice-versa.
+
+This function is a wrapper over `calc-not'.
+
+* References
+- info node `(calc) Binary Functions'
+- `calc-not'"
+ (interactive)
+ (call-interactively #'calc-not))
+
+(defun casual-calc--calc-lshift-binary ()
+  "Shifts a number left by one bit.
+\nStack Arguments:
+1: n
+
+This function is a wrapper over `calc-lshift-binary'.
+
+* References
+- info node `(calc) Binary Functions'
+- `calc-lshift-binary'"
+ (interactive)
+ (call-interactively #'calc-lshift-binary))
+
+(defun casual-calc--calc-rshift-binary ()
+    "Shifts a number right by one bit.
+\nStack Arguments:
+1: n
+
+This function is a wrapper over `calc-rshift-binary'.
+
+* References
+- info node `(calc) Binary Functions'
+- `calc-rshift-binary'"
+ (interactive)
+ (call-interactively #'calc-rshift-binary))
+
+(defun casual-calc--calc-lshift-arith ()
+  "Arithmetic shift left by one bit.
+\nStack Arguments:
+1: n
+
+This function is a wrapper over `calc-lshift-arith'.
+
+* References
+- info node `(calc) Binary Functions'
+- `calc-lshift-arith'"
+ (interactive)
+ (call-interactively #'calc-lshift-arith))
+
+(defun casual-calc--calc-rshift-arith ()
+  "Arithmetic shift right by one bit.
+\nStack Arguments:
+1: n
+
+This command performs an “arithmetic” shift to the right, in
+which the leftmost bit (according to the current word size) is
+duplicated rather than shifting in zeros. This corresponds to
+dividing by a power of two where the input is interpreted as a
+signed, twos-complement number. (The distinction between the
+‘binary’ and ‘arithmetic’ operations is totally independent from
+whether the word size is positive or negative.)
+
+This function is a wrapper over `calc-rshift-arith'.
+
+* References
+- info node `(calc) Binary Functions'
+- `calc-rshift-arith'"
+ (interactive)
+ (call-interactively #'calc-rshift-arith))
+
+(defun casual-calc--calc-rotate-binary ()
+  "Rotates a number one bit to the left.
+\nStack Arguments:
+1: n
+
+The leftmost bit (according to the current word size) is dropped
+off the left and shifted in on the right.
+
+This function is a wrapper over `calc-rotate-binary'.
+
+* References
+- info node `(calc) Binary Functions'
+- `calc-rotate-binary'"
+ (interactive)
+ (call-interactively #'calc-rotate-binary))
+
+(defun casual-calc--calc-word-size ()
+    "Set the word size from a prompt.
+
+This command displays a prompt with the current word size; press
+<RET> immediately to keep this word size, or type a new word size
+at the prompt. Default word size is 32.
+
+This function is a wrapper over function `calc-word-size'.
+
+* References
+- info node `(calc) Binary Functions'
+- function `calc-word-size'"
+ (interactive)
+ (call-interactively #'calc-word-size))
+
+(defun casual-calc--calc-unpack-bits ()
+    "Unpack into set of bit indexes.
+\nStack Arguments:
+1: n
+
+This function is a wrapper over `calc-unpack-bits'.
+
+* References
+- info node `(calc) Binary Functions'
+- `calc-unpack-bits'"
+ (interactive)
+ (call-interactively #'calc-unpack-bits))
+
+(defun casual-calc--calc-pack-bits ()
+    "Pack set of bit indexes into a number.
+\nStack Arguments:
+1: n
+
+This function is a wrapper over `calc-pack-bits'.
+
+* References
+- info node `(calc) Binary Functions'
+- `calc-pack-bits'"
+ (interactive)
+ (call-interactively #'calc-pack-bits))
 
 (provide 'casual-calc-binary)
 ;;; casual-calc-binary.el ends here

--- a/scripts/wrap-calc.py
+++ b/scripts/wrap-calc.py
@@ -64,7 +64,7 @@ class Application:
             self.stdout = outfile
 
         self.wrappedCalcFunctionTemplate = Template(
-"""(defun casual-$fn ()
+"""(defun casual-calc--$fn ()
     "TODO: This function does not yet have a docstring.
 \\nStack Arguments:
 1: n
@@ -79,10 +79,10 @@ This function is a wrapper over `$fn'.
         )
 
         self.wrappedCalcFunctionTestTemplate = Template(
-            """;; (ert-deftest test-casual-$fn ()
+            """;; (ert-deftest test-casual-calc--$fn ()
 ;;   (casualt-setup)
 ;;   (calc-push 10)
-;;   (casualt-testbench-calc-fn #'casual-$fn
+;;   (casualt-testbench-calc-fn #'casual-calc--$fn
 ;;                              '()
 ;;                              '(float 647943975411 -8))
 ;;   (casualt-breakdown t))"""

--- a/tests/casual-calc-test-utils.el
+++ b/tests/casual-calc-test-utils.el
@@ -161,7 +161,7 @@ appending \"q\" to the keysequence."
               (casualt-testbench-transient-suffix menu
                                                   key
                                                   cmd
-                                                  (funcall value-fn))))
+                                                  (funcall-interactively value-fn))))
           test-vectors))
 
 

--- a/tests/test-casual-calc-binary.el
+++ b/tests/test-casual-calc-binary.el
@@ -27,24 +27,124 @@
 (require 'casual-calc-test-utils)
 (require 'casual-calc-binary)
 
-(ert-deftest test-casual-calc-binary-tmenu ()
+(ert-deftest test-casual-calc-binary-tmenu-bindings ()
+  (casualt-setup)
+  (let ((test-vectors '(("a" . casual-calc--calc-and)
+                        ("o" . casual-calc--calc-or)
+                        ("x" . casual-calc--calc-xor)
+                        ("-" . casual-calc--calc-diff)
+                        ("!" . casual-calc--calc-not)
+
+                        ("lq" . casual-calc--calc-lshift-binary)
+                        ("rq" . casual-calc--calc-rshift-binary)
+
+                        ("ìq" . casual-calc--calc-lshift-arith)
+                        ("òq" . casual-calc--calc-rshift-arith)
+                        ("q" . casual-calc--calc-rotate-binary)
+
+                        ("Rq" . casual-calc-radix-tmenu)
+                        ("wq" . casual-calc--calc-word-size)
+                        ("u" . casual-calc--calc-unpack-bits)
+                        ("p" . casual-calc--calc-pack-bits))))
+
+    (casualt-suffix-testbench-runner test-vectors
+                                     #'casual-calc-binary-tmenu
+                                     '(lambda () (random 5000))))
+  (casualt-breakdown t))
+
+
+(ert-deftest test-casual-calc--calc-and ()
+  (casualt-setup)
+  (calc-push 11)
+  (calc-push 12)
+  (call-interactively #'casual-calc--calc-and)
+  (should (= (calc-top) 8))
+
+  (casualt-breakdown t))
+
+(ert-deftest test-casual-calc--calc-or ()
+  (casualt-setup)
+  (calc-push 11)
+  (calc-push 12)
+  (call-interactively #'casual-calc--calc-or)
+  (should (= (calc-top) 15))
+  (casualt-breakdown t))
+
+(ert-deftest test-casual-calc--calc-xor ()
+  (casualt-setup)
+  (calc-push 11)
+  (calc-push 12)
+  (call-interactively #'casual-calc--calc-xor)
+  (should (= (calc-top) 7))
+  (casualt-breakdown t))
+
+(ert-deftest test-casual-calc--calc-diff ()
+  (casualt-setup)
+  (calc-push 11)
+  (calc-push 12)
+  (call-interactively #'casual-calc--calc-diff)
+  (should (= (calc-top) 3))
+  (casualt-breakdown t))
+
+(ert-deftest test-casual-calc--calc-not ()
   (casualt-setup)
   (calc-word-size 8)
-  (casualt-run-menu-input-testcases
-   'casual-calc-binary-tmenu
-   '(("a" (11 12) 8)
-     ("o" (11 12) 15)
-     ("x" (11 12) 7)
-     ("-" (11 12) 3)
-     ("!" (11) 244)
-     ("l" (12) 24)
-     ("r" (24) 12)
-     ([134217836] (12) 24) ; (read-kbd-macro "M-l") evals to [134217836]
-     ([134217842] (24) 12) ; (read-kbd-macro "M-r") evals to [134217842]
-     ([18] (24) 48) ; (read-kbd-macro "C-r") evals to [18]
-     ))
-  (calc-word-size 32)
+  (calc-push 11)
+  (call-interactively #'casual-calc--calc-not)
+  (should (= (calc-top) 244))
   (casualt-breakdown t))
+
+(ert-deftest test-casual-calc--calc-lshift-binary ()
+  (casualt-setup)
+  (calc-word-size 8)
+  (calc-push 12)
+  (call-interactively #'casual-calc--calc-lshift-binary)
+  (should (= (calc-top) 24))
+  (casualt-breakdown t))
+
+(ert-deftest test-casual-calc--calc-rshift-binary ()
+  (casualt-setup)
+  (calc-word-size 8)
+  (calc-push 24)
+  (call-interactively #'casual-calc--calc-rshift-binary)
+  (should (= (calc-top) 12))
+  (casualt-breakdown t))
+
+(ert-deftest test-casual-calc--calc-lshift-arith ()
+  (casualt-setup)
+  (calc-word-size 8)
+  (calc-push 12)
+  (call-interactively #'casual-calc--calc-lshift-arith)
+  (should (= (calc-top) 24))
+  (casualt-breakdown t))
+
+(ert-deftest test-casual-calc--calc-rshift-arith ()
+  (casualt-setup)
+  (calc-word-size 8)
+  (calc-push 24)
+  (call-interactively #'casual-calc--calc-rshift-arith)
+  (should (= (calc-top) 12))
+  (casualt-breakdown t))
+
+(ert-deftest test-casual-calc--calc-rotate-binary ()
+  (casualt-setup)
+  (calc-word-size 8)
+  (calc-push 24)
+  (call-interactively #'casual-calc--calc-rotate-binary)
+  (should (= (calc-top) 48))
+  (casualt-breakdown t))
+
+;; (ert-deftest test-casual-calc--calc-word-size ()
+;;   (casualt-setup)
+;;   (casualt-breakdown t))
+
+;; (ert-deftest test-casual-calc--calc-unpack-bits ()
+;;   (casualt-setup)
+;;   (casualt-breakdown t))
+
+;; (ert-deftest test-casual-calc--calc-pack-bits ()
+;;   (casualt-setup)
+;;   (casualt-breakdown t))
 
 (provide 'test-casual-calc-binary)
 ;;; test-casual-calc-binary.el ends here


### PR DESCRIPTION
- Persist binary menu after changing radix, setting word size, toggling leading
  zeros.
- Add configuration of calc-group-char.
- Wrap binary calc functions to support docstrings and testing.
