### PR TITLE
Update README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -45,7 +45,7 @@ If you use ~use-package~, here is the recipe for installing it.
            ("C-o" . casual-calc-tmenu)
            :map
            calc-alg-map
-           ("C-o" . casual-calc-tmenu)))
+           ("C-o" . casual-calc-tmenu))
     :after (calc))
 #+end_src
 


### PR DESCRIPTION
Removed a single closing parentheses that was creating an error when I tried it. This slightly changed expression should now work out of the box. Based on manually counting the parentheses, I'm pretty sure this is a typo in the use-package declaration and not something to do with my specific environment.