### PR TITLE
Use `casual-lib-use-unicode` for math symbols

### DIFF
--- a/lisp/casual-calc-angle-measure.el
+++ b/lisp/casual-calc-angle-measure.el
@@ -35,9 +35,13 @@
    :description (lambda ()
                   (format "Angle Measure (now %s)›"
                           (casual-calc-angle-mode-label)))
-   ("d" "Degrees" calc-degrees-mode :transient nil)
-   ("r" "Radians" calc-radians-mode :transient nil)
-   ("h" "Degrees-Minutes-Seconds" calc-hms-mode :transient nil)]
+   ("d" "Degrees" calc-degrees-mode
+    :description (lambda () (casual-calc-unicode-get :degrees))
+    :transient nil)
+   ("r" "Radians" calc-radians-mode
+    :description (lambda () (casual-calc-unicode-get :radians))
+    :transient nil)
+   ("h" "Hours-Minutes-Seconds" calc-hms-mode :transient nil)]
   [:class transient-row
           (casual-lib-quit-one)
           (casual-calc-algebraic-entry)

--- a/lisp/casual-calc-conversion.el
+++ b/lisp/casual-calc-conversion.el
@@ -31,12 +31,25 @@
 (transient-define-prefix casual-calc-conversions-tmenu ()
   "Casual conversion functions menu."
   [["Conversions"
-    ("d" "To Degrees" calc-to-degrees :transient t)
-    ("r" "To Radians" calc-to-radians :transient t)
+    ("d" "To Degrees" calc-to-degrees
+     :description (lambda ()
+                    (format "%s %s %s"
+                            (casual-calc-unicode-get :radians)
+                            (casual-calc-unicode-get :to)
+                            (casual-calc-unicode-get :degrees)))
+     :transient t)
+    ("r" "To Radians" calc-to-radians
+     :description (lambda ()
+                    (format "%s %s %s"
+                            (casual-calc-unicode-get :degrees)
+                            (casual-calc-unicode-get :to)
+                            (casual-calc-unicode-get :radians)))
+     :transient t)
     ("h" "To HMS" calc-to-hms :transient t)
     ("f" "To Float" calc-float :transient t)
-    ("F" "To Fraction" calc-fraction :transient t)]
-   casual-calc-operators-group]
+    ("F" "To Fraction" calc-fraction :transient t)]]
+
+  casual-calc-operators-group-row
 
   casual-calc-navigation-group)
 

--- a/lisp/casual-calc-labels.el
+++ b/lisp/casual-calc-labels.el
@@ -77,8 +77,8 @@ can be subsequently edited or removed."
 (defun casual-calc-angle-mode-label ()
   "Label for angle mode."
   (cond
-   ((eq calc-angle-mode 'deg) "Degrees")
-   ((eq calc-angle-mode 'rad) "Radians")
+   ((eq calc-angle-mode 'deg) (casual-calc-unicode-get :degrees))
+   ((eq calc-angle-mode 'rad) (casual-calc-unicode-get :radians))
    ((eq calc-angle-mode 'hms) "hms")))
 
 (defun casual-calc-complex-format-label ()

--- a/lisp/casual-calc-logarithmic.el
+++ b/lisp/casual-calc-logarithmic.el
@@ -32,19 +32,33 @@
   "Casual logarithmic functions."
   ["Logarithmic Functions"
    ["Logarithm"
-    ("l" "𝑙𝑛" calc-ln :transient t)
-    ("p" "𝑙𝑛(𝑥+𝟣)" calc-lnp1 :transient t)
-    ("1" "𝑙𝑜𝑔₁₀" calc-log10 :transient t)
-    ("L" "𝑙𝑜𝑔ₐ(𝑥)" calc-log :transient t)]
+    ("l" "𝑙𝑛" calc-ln
+     :description (lambda () (casual-calc-unicode-get :ln))
+     :transient t)
+    ("p" "𝑙𝑛(𝑥+𝟣)" calc-lnp1
+     :description (lambda () (casual-calc-unicode-get :lnp1))
+     :transient t)
+    ("1" "𝑙𝑜𝑔₁₀" calc-log10
+     :description (lambda () (casual-calc-unicode-get :log10))
+     :transient t)
+    ("L" "𝑙𝑜𝑔ₐ(𝑥)" calc-log
+     :description (lambda () (casual-calc-unicode-get :log))
+     :transient t)]
 
    ["Exponential"
-    ("^" "𝑒ˣ" calc-exp :transient t)
-    ("m" "𝑒ˣ-𝟣" calc-expm1 :transient t)]
+    ("^" "𝑒ˣ" calc-exp
+     :description (lambda () (casual-calc-unicode-get :exp))
+     :transient t)
+    ("m" "𝑒ˣ-𝟣" calc-expm1
+     :description (lambda () (casual-calc-unicode-get :expm1))
+     :transient t)]
 
    ["Constant"
-    ("e" "𝑒" casual-calc--e-constant :transient t)]
-   casual-calc-operators-group]
+    ("e" "𝑒" casual-calc--e-constant
+     :description (lambda () (casual-calc-unicode-get :e))
+     :transient t)]]
 
+  casual-calc-operators-group-row
   casual-calc-navigation-group)
 
 (provide 'casual-calc-logarithmic)

--- a/lisp/casual-calc-random.el
+++ b/lisp/casual-calc-random.el
@@ -46,13 +46,14 @@
     ("r" "Natural within [𝟢..𝑚)" casual-calc--random-interval-0-to-m :transient t)]
 
    ["Real Number"
-    ("c" "Real within [𝟢.𝟢..𝟣.𝟢)" calc-rrandom :transient t)]
-
-   casual-calc-operators-group]
+    ("c" "Real within [𝟢.𝟢..𝟣.𝟢)" calc-rrandom :transient t)]]
 
   ;;("r" "Random number within [0..𝑛)" calc-random :transient nil)
 
-  [("a" "Random number again" calc-random-again :transient t)]
+  ["Repeat"
+   ("a" "Random number again" calc-random-again :transient t)]
+
+  casual-calc-operators-group-row
   casual-calc-navigation-group)
 
 (provide 'casual-calc-random)

--- a/lisp/casual-calc-trigonometric.el
+++ b/lisp/casual-calc-trigonometric.el
@@ -34,27 +34,53 @@
   ;; ["Arguments"
   ;;  ("i" "inverse" "-inverse")
   ;;  ("h" "hyperbolic" "-hyperbolic")]
-  [["Trig"
-    ("s" "sin" calc-sin :transient t)
-    ("c" "cos" calc-cos :transient t)
-    ("t" "tan" calc-tan :transient t)]
-   ["Inverse"
-    ("S" "arcsin" calc-arcsin :transient t)
-    ("C" "arccos" calc-arccos :transient t)
-    ("T" "arctan" calc-arctan :transient t)]
+  ["Trigonometric Functions"
+   [("s" "sin" calc-sin
+     :description (lambda () (casual-calc-unicode-get :sin))
+     :transient t)
+    ("c" "cos" calc-cos
+     :description (lambda () (casual-calc-unicode-get :cos))
+     :transient t)
+    ("t" "tan" calc-tan
+     :description (lambda () (casual-calc-unicode-get :tan))
+     :transient t)]
+   [("S" "arcsin" calc-arcsin
+     :description (lambda () (casual-calc-unicode-get :arcsin))
+     :transient t)
+    ("C" "arccos" calc-arccos
+     :description (lambda () (casual-calc-unicode-get :arccos))
+     :transient t)
+    ("T" "arctan" calc-arctan
+     :description (lambda () (casual-calc-unicode-get :arctan))
+     :transient t)]
 
-   ["Misc"
-    ("p" "𝜋" casual-calc--pi :transient t)
-    ("d" "To Degrees" calc-to-degrees :transient t)
-    ("r" "To Radians" calc-to-radians :transient t)
-    ("a" casual-calc-angle-measure-tmenu
+   [("d" "To Degrees" calc-to-degrees
+     :description (lambda ()
+                    (format "%s %s %s"
+                            (casual-calc-unicode-get :radians)
+                            (casual-calc-unicode-get :to)
+                            (casual-calc-unicode-get :degrees)))
+     :transient t)
+    ("r" "To Radians" calc-to-radians
+     :description (lambda ()
+                    (format "%s %s %s"
+                            (casual-calc-unicode-get :degrees)
+                            (casual-calc-unicode-get :to)
+                            (casual-calc-unicode-get :radians)))
+     :transient t)]]
+
+  [:class transient-row
+   ("p" "𝜋" casual-calc--pi
+     :description (lambda () (casual-calc-unicode-get :pi))
+     :transient t)
+   ("a" casual-calc-angle-measure-tmenu
      :description (lambda ()
                     (format "Angle Measure (now %s)›"
                             (casual-calc-angle-mode-label)))
      :transient t)
-    ("h" "Hyperbolic›" casual-calc-hyperbolic-trig-tmenu)]
-   casual-calc-operators-group]
+   ("h" "Hyperbolic›" casual-calc-hyperbolic-trig-tmenu)]
 
+  casual-calc-operators-group-row
   casual-calc-navigation-group)
 
 

--- a/lisp/casual-calc-utils.el
+++ b/lisp/casual-calc-utils.el
@@ -28,12 +28,52 @@
 (require 'transient)
 (require 'casual-lib)
 
+(defconst casual-calc-unicode-db
+  '((:inv . '("1/𝑥" "1/x"))
+    (:sqrt . '("√" "sqrt"))
+    (:change-sign . '("∓" "+/-"))
+    (:power . '("𝑦ˣ" "y^x"))
+    (:abs . '("|𝑥|" "|x|"))
+    (:factorial . '(" !" "!"))
+    (:percent . '(" ٪" "%"))
+    (:percent-change . '(" Δ%" "% change"))
+    (:pi . '("𝜋" "pi"))
+    (:e . '("𝑒" "e"))
+    (:ln . '("𝑙𝑛" "ln"))
+    (:lnp1 . '("𝑙𝑛(𝑥+𝟣)" "ln(x+1)"))
+    (:log10 . '("𝑙𝑜𝑔₁₀" "log10"))
+    (:log . '("𝑙𝑜𝑔ₐ(𝑥)" "log"))
+    (:exp . '("𝑒ˣ" "e^x"))
+    (:expm1 . '("𝑒ˣ-𝟣" "e^x - 1"))
+    (:sin . '("𝑠𝑖𝑛" "sin"))
+    (:cos . '("𝑐𝑜𝑠" "cos"))
+    (:tan . '("𝑡𝑎𝑛" "tan"))
+    (:stack . '("≣" "Stack"))
+    (:arcsin . '("𝑎𝑟𝑐𝑠𝑖𝑛" "arcsin"))
+    (:arccos . '("𝑎𝑟𝑐𝑐𝑜𝑠" "arccos"))
+    (:arctan . '("𝑎𝑟𝑐𝑡𝑎𝑛" "arctan"))
+    (:degrees . '("°" "Degrees"))
+    (:radians . '("𝑟𝑎𝑑" "Radians"))
+    (:to . '("→" "to")))
+  "Unicode symbol DB to use for Calc Transient menus.")
+
+(defun casual-calc-unicode-get (key)
+  "Lookup Unicode symbol for KEY in DB.
+
+- KEY symbol used to lookup Unicode symbol in DB.
+
+If the value of customizable variable `casual-lib-use-unicode'
+is non-nil, then the Unicode symbol is returned, otherwise a
+plain ASCII-range string."
+  (casual-lib-unicode-db-get key casual-calc-unicode-db))
+
 ;; Transient Navigation
 (transient-define-suffix casual-calc-undo-suffix ()
   "Undo stack."
   :transient t
   :key "U"
-  :description "Undo ≣"
+  :description (lambda () (format "Undo %s"
+                                  (casual-calc-unicode-get :stack)))
   (interactive)
   (call-interactively #'calc-undo))
 
@@ -71,6 +111,15 @@
 
 (defconst casual-calc-operators-group
   ["Operators"
+    ("+" "add" casual-calc--plus :transient t)
+    ("-" "sub" casual-calc--minus :transient t)
+    ("*" "mul" casual-calc--times :transient t)
+    ("/" "div" casual-calc--divide :transient t)
+    ("%" "mod" casual-calc--mod :transient t)])
+
+(defconst casual-calc-operators-group-row
+  ["Operators"
+   :class transient-row
     ("+" "add" casual-calc--plus :transient t)
     ("-" "sub" casual-calc--minus :transient t)
     ("*" "mul" casual-calc--times :transient t)

--- a/lisp/casual-calc.el
+++ b/lisp/casual-calc.el
@@ -75,19 +75,39 @@
 (transient-define-prefix casual-calc-tmenu ()
   "Casual Calc main menu."
   [["Calc"
-    ("&" "1/x" casual-calc--inv :transient t)
-    ("Q" "√" casual-calc--sqrt :transient t)
-    ("n" "∓" casual-calc--change-sign :transient t)
-    ("^" "𝑦ˣ" casual-calc--power :transient t)
+    ("&" "1/x" casual-calc--inv
+     :description (lambda () (casual-calc-unicode-get :inv))
+     :transient t)
+    ("Q" "√" casual-calc--sqrt
+     :description (lambda () (casual-calc-unicode-get :sqrt))
+     :transient t)
+    ("n" "∓" casual-calc--change-sign
+     :description (lambda () (casual-calc-unicode-get :change-sign))
+     :transient t)
+    ("^" "𝑦ˣ" casual-calc--power
+     :description (lambda () (casual-calc-unicode-get :power))
+     :transient t)
     ("=" "=" casual-calc--evaluate :transient t)]
    [""
-    ("A" "|𝑥|" casual-calc--abs :transient t)
-    ("!" " !" casual-calc--factorial :transient t)
-    ("%" " ٪" casual-calc--percent :transient t)
-    ("D" " Δ%" casual-calc--percent-change :transient t)]
+    ("A" "|𝑥|" casual-calc--abs
+     :description (lambda () (casual-calc-unicode-get :abs))
+     :transient t)
+    ("!" " !" casual-calc--factorial
+     :description (lambda () (casual-calc-unicode-get :factorial))
+     :transient t)
+    ("%" " ٪" casual-calc--percent
+     :description (lambda () (casual-calc-unicode-get :percent))
+     :transient t)
+    ("D" " Δ%" casual-calc--percent-change
+     :description (lambda () (casual-calc-unicode-get :percent-change))
+     :transient t)]
    ["Constants"
-    ("p" "𝜋" casual-calc--pi :transient t)
-    ("e" "𝑒" casual-calc--e-constant :transient t)]
+    ("p" "𝜋" casual-calc--pi
+     :description (lambda () (casual-calc-unicode-get :pi))
+     :transient t)
+    ("e" "𝑒" casual-calc--e-constant
+     :description (lambda () (casual-calc-unicode-get :e))
+     :transient t)]
 
    casual-calc-basic-operators-group
 


### PR DESCRIPTION
- Refactor labels to honor variable `casual-lib-use-unicode` to render math symbols.
