### PR TITLE
Sync `Version:` commit with release tag for package build

### DIFF
--- a/README.org
+++ b/README.org
@@ -8,7 +8,7 @@ An opinionated [[https://github.com/magit/transient][Transient]]-based user inte
 * Motivation
 While Emacs Calc has an embarrassingly rich feature set, for many users this capability is inaccessible due the overwhelming number of keybindings used to access them. These keybindings have a steep learning curve that is quickly lost if not in constant use.
 
-Menus are a user interface (UI) affordance that offer users discoverability and recall. Providing a hierarchical menu UI over Calc greatly improves its casual use.
+Menus are a user interface (UI) affordance that offer users discoverability and recognition. Providing a hierarchical menu UI over Calc greatly improves its casual use.
 
 ** Goals
 - To provide a keyboard-driven UI to Calc that is menu based.


### PR DESCRIPTION
This changes the build process to sync the package `Version:` field commit
with the release tag. This is to support use-package :vc in the upcoming Emacs
30 release.

Also minor copy change to README.org
