### PR TITLE
Merge development to main 20240930_222500

### DIFF
--- a/README.org
+++ b/README.org
@@ -8,7 +8,7 @@ An opinionated [[https://github.com/magit/transient][Transient]]-based user inte
 * Motivation
 While Emacs Calc has an embarrassingly rich feature set, for many users this capability is inaccessible due the overwhelming number of keybindings used to access them. These keybindings have a steep learning curve that is quickly lost if not in constant use.
 
-Menus are a user interface (UI) affordance that offer users discoverability and recall. Providing a hierarchical menu UI over Calc greatly improves its casual use.
+Menus are a user interface (UI) affordance that offer users discoverability and recognition. Providing a hierarchical menu UI over Calc greatly improves its casual use.
 
 ** Goals
 - To provide a keyboard-driven UI to Calc that is menu based.

--- a/lisp/casual-calc-version.el
+++ b/lisp/casual-calc-version.el
@@ -22,7 +22,7 @@
 
 ;;; Code:
 
-(defconst casual-calc-version "1.11.4-rc.1"
+(defconst casual-calc-version "1.11.4-rc.2"
   "Casual Version.")
 
 (defun casual-calc-version ()

--- a/lisp/casual-calc-version.el
+++ b/lisp/casual-calc-version.el
@@ -22,7 +22,7 @@
 
 ;;; Code:
 
-(defconst casual-calc-version "1.11.3"
+(defconst casual-calc-version "1.11.4-rc.1"
   "Casual Version.")
 
 (defun casual-calc-version ()

--- a/lisp/casual-calc.el
+++ b/lisp/casual-calc.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual-calc
 ;; Keywords: tools
-;; Version: 1.11.3
+;; Version: 1.11.4-rc.1
 ;; Package-Requires: ((emacs "29.1") (casual-lib "1.1.0"))
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/lisp/casual-calc.el
+++ b/lisp/casual-calc.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual-calc
 ;; Keywords: tools
-;; Version: 1.11.4-rc.1
+;; Version: 1.11.4-rc.2
 ;; Package-Requires: ((emacs "29.1") (casual-lib "1.1.0"))
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
- **Sync `Version:` commit with release tag for package build**
  This changes the build process to sync the package `Version:` field commit
  with the release tag. This is to support use-package :vc in the upcoming Emacs
  30 release.
  
  Also minor copy change to README.org
  

